### PR TITLE
Ability to specify spoiler text color

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ $ git clone git@github.com:infobyte/spoilerwall.git
 
 2. Edit the file `server-spoiler.py` and set the **HOST** and **PORT** variables.
 
-3. Run the server
+3. Change spoiler color (or not?), default green
+
+4. Run the server
 
 ```
 $ python2 server-spoiler.py

--- a/server-spoiler.py
+++ b/server-spoiler.py
@@ -26,6 +26,9 @@ PORT = 8080
 FILE_SPOILER = "spoilers.json"
 MAX_SPOILER_COUNT = 4200
 
+SPOILER_COLOR = '\033[92m'
+ASCII_NO_COLOR = '\033[0m'
+
 
 class MyTCPHandler(server.BaseRequestHandler):
 
@@ -36,7 +39,7 @@ class MyTCPHandler(server.BaseRequestHandler):
         chosen = random.choice(movies)
         spoiler_chosen = chosen['name'] + '\n' + ' '.join([x['value'] for x in chosen['spoilers']]) + '\n'
 
-        self.request.sendall(spoiler_chosen.encode('ascii','ignore'))
+        self.request.sendall(SPOILER_COLOR + spoiler_chosen.encode('ascii','ignore') + ASCII_NO_COLOR)
         self.request.close()
 
 if __name__ == "__main__":


### PR DESCRIPTION
When connecting e.g. via telnet, spoiler content gets lost between telnet output.
Adding color fixes problem.